### PR TITLE
#3 - set Doctype

### DIFF
--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <configuration>
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
it is cleaner and avoids warnings in Eclipse

Signed-off-by: Aurélien Pupier <apupier@redhat.com>